### PR TITLE
Small improvements: /usr/bin/env and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+libbie_icons

--- a/libbie.sh
+++ b/libbie.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 GH_REPOSITORY="https://github.com/redsPL/libbieoffice"
 if [[ $1 == "--help" || $1 == "-h" ]]; then
 	echo "libbie.sh - script for replacing LibreOffice images"


### PR DESCRIPTION
### /usr/bin/env
Changed `/bin/bash` to `/usr/bin/env bash` for more compatible bash detection. Caused some issues on my NixOS since bash does not reside in /bin/bash by default. Should work on other distros too (_Though I'd still clone this branch and test before merging_)

Also the script as a whole does not work on NixOs, which is expected due to its system structure. Which is why I might do another PR to fix that issue.

### .gitignore
Added  `libbie_icons` to a .gitignore since I'm assuming it's not meant to be pushed back to upstream.

